### PR TITLE
scala 3 rc1 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ object core extends TpolecatModule {
 
 I can't promise this plugin will work for old minor releases of Scala. It has been tested with:
 
+* 3.0.0-RC1
 * 2.13.2
 * 2.12.11
 * 2.11.12

--- a/build.sc
+++ b/build.sc
@@ -8,7 +8,7 @@ object tpolecat extends ScalaModule with PublishModule {
   def scalaVersion = "2.13.4"
   def artifactName = "mill-tpolecat"
 
-  def publishVersion = "0.2.0"
+  def publishVersion = "0.2.1"
   def pomSettings = PomSettings(
     description = "scalac options for the enlightened",
     organization = "io.github.davidgregory084",

--- a/itest/src/scala300RC1/build.sc
+++ b/itest/src/scala300RC1/build.sc
@@ -1,0 +1,52 @@
+import $exec.plugins
+import io.github.davidgregory084.TpolecatModule
+import mill._
+import mill.scalalib.ScalaModule
+
+object project extends ScalaModule with TpolecatModule {
+  override def scalaVersion = "3.0.0-RC1"
+}
+
+def verify() = T.command {
+  assert(project.scalacOptions() == Seq(
+    "-encoding",
+    "utf8",
+    "-explaintypes",
+    "-feature",
+    "-language:existentials",
+    "-language:experimental.macros",
+    "-language:higherKinds",
+    "-language:implicitConversions",
+    "-unchecked",
+    "-Xcheckinit",
+    "-Xfatal-warnings",
+    "-Xlint:adapted-args",
+    "-Xlint:constant",
+    "-Xlint:delayedinit-select",
+    "-Xlint:deprecation",
+    "-Xlint:doc-detached",
+    "-Xlint:inaccessible",
+    "-Xlint:infer-any",
+    "-Xlint:missing-interpolator",
+    "-Xlint:nullary-override",
+    "-Xlint:nullary-unit",
+    "-Xlint:option-implicit",
+    "-Xlint:package-object-classes",
+    "-Xlint:poly-implicit-overload",
+    "-Xlint:private-shadow",
+    "-Xlint:stars-align",
+    "-Xlint:type-parameter-shadow",
+    "-Wunused:nowarn",
+    "-Wdead-code",
+    "-Wextra-implicit",
+    "-Wnumeric-widen",
+    "-Wunused:implicits",
+    "-Wunused:explicits",
+    "-Wunused:imports",
+    "-Wunused:locals",
+    "-Wunused:params",
+    "-Wunused:patvars",
+    "-Wunused:privates",
+    "-Wvalue-discard"
+  ))
+}

--- a/tpolecat/src/io/github/davidgregory084/ScalaVersion.scala
+++ b/tpolecat/src/io/github/davidgregory084/ScalaVersion.scala
@@ -7,6 +7,7 @@ object ScalaVersion {
   def apply(scalaVersion: String): ScalaVersion = scalaVersion match {
     case ReleaseVersion(major, minor, patch) => ScalaVersion(major.toInt, minor.toInt, patch.toInt)
     case MinorSnapshotVersion(major, minor, patch) => ScalaVersion(major.toInt, minor.toInt, patch.toInt)
+    case Scala3Version(minor, patch, _) => ScalaVersion(3, minor.toInt, patch.toInt)
     case DottyVersion("0", minor, patch) => ScalaVersion(3, minor.toInt, patch.toInt)
   }
 

--- a/tpolecat/src/io/github/davidgregory084/Tpolecat.scala
+++ b/tpolecat/src/io/github/davidgregory084/Tpolecat.scala
@@ -5,9 +5,9 @@ import scala.Ordering.Implicits._
 
 object Tpolecat {
   private val allScalacOptions = Seq(
-    ScalacOption("-Xsource:3", isSupported = v211 <= _),                                                                     // Treat compiler input as Scala source for the specified version, see scala/bug#8126.
+    ScalacOption("-Xsource:3", isSupported = _ < v300),                                                                      // Treat compiler input as Scala source for the specified version, see scala/bug#8126.
     ScalacOption("-deprecation", isSupported = version => version < v213 || v300 <= version),                                // Emit warning and location for usages of deprecated APIs. Not really removed but deprecated in 2.13.
-    ScalacOption("-migration", isSupported = v300 <= _),                                                                     // Emit warning and location for migration issues from Scala 2.
+    ScalacOption("-migration", isSupported = _ < v300),                                                                      // Emit warning and location for migration issues from Scala 2.
     ScalacOption("-explaintypes", isSupported = _ < v300),                                                                   // Explain type errors in more detail.
     ScalacOption("-explain-types", isSupported = v300 <= _),                                                                 // Explain type errors in more detail.
     ScalacOption("-explain", isSupported = v300 <= _),                                                                       // Explain errors in more detail.


### PR DESCRIPTION
Scala 3 RC1 is out (yay). The intent of this PR is to provide support for Scala 3 RC candidates.

I changed two of the rules because I got compiler errors in a 3.0.0-RC1 project. I was also unable to run the tests, but I did add a subproject for 3.0.0-RC1:

```bash
mill-tpolecat (scala3-support):>mill itest.test
[59/59] itest.test 
Publishing Artifact(io.github.davidgregory084,mill-tpolecat_2.13,0.2.1) to ivy repo /Users/home/projects/mill-tpolecat/out/itest/test/dest/ivyRepo/local
Starting integration test [1/4]: scala211
Invoking integration test [1/4]: scala211: Targets(targets=List(verify),expectedExitCode=0)
Failed integration test [1/4]: scala211
Starting integration test [2/4]: scala212
Invoking integration test [2/4]: scala212: Targets(targets=List(verify),expectedExitCode=0)
Failed integration test [2/4]: scala212
Starting integration test [3/4]: scala213
Invoking integration test [3/4]: scala213: Targets(targets=List(verify),expectedExitCode=0)
Failed integration test [3/4]: scala213
Starting integration test [4/4]: scala300RC1
Invoking integration test [4/4]: scala300RC1: Targets(targets=List(verify),expectedExitCode=0)
Failed integration test [4/4]: scala300RC1
1 targets failed
itest.test java.lang.IllegalArgumentException: Unknown ansi-escape [1A at index 445 inside string cannot be parsed into an fansi.Str
    fansi.ErrorMode$Throw$.handle(Fansi.scala:419)
    fansi.ErrorMode$Throw$.handle(Fansi.scala:407)
    fansi.Str$.apply(Fansi.scala:272)
    fansi.Str$.implicitApply(Fansi.scala:227)
    mill.util.PrintLogger.error(Loggers.scala:120)
    mill.util.PrefixLogger.error(Loggers.scala:85)
    mill.util.MultiLogger.error(Loggers.scala:219)
    mill.util.ProxyLogger.error(Loggers.scala:250)
    de.tobiasroeser.mill.integrationtest.MillIntegrationTestModule.$anonfun$testTask$2(MillIntegrationTestModule.scala:235)
    de.tobiasroeser.mill.integrationtest.MillIntegrationTestModule.$anonfun$testTask$2$adapted(MillIntegrationTestModule.scala:64)
    mill.define.ApplyerGenerated.$anonfun$zipMap$7(ApplicativeGenerated.scala:17)
    mill.define.Task$MappedDest.evaluate(Task.scala:391)
```

I wouldn't mind adding some instructions to the README to make it easier for people to run them.