### PR TITLE
fix: handle Scala 3 nightly version for community build

### DIFF
--- a/itest/src/scala3Nightly/build.sc
+++ b/itest/src/scala3Nightly/build.sc
@@ -1,0 +1,25 @@
+import $exec.plugins
+import io.github.davidgregory084.TpolecatModule
+import mill._
+import mill.scalalib.ScalaModule
+
+object project extends ScalaModule with TpolecatModule {
+  override def scalaVersion = "3.2.2-RC1-bin-20221021-d9301e0-NIGHTLY"
+}
+
+def verify() = T.command {
+  assert(project.scalacOptions() == Seq(
+    "-encoding",
+    "utf8",
+    "-deprecation",
+    "-explain-types",
+    "-explain",
+    "-feature",
+    "-language:experimental.macros",
+    "-language:higherKinds",
+    "-language:implicitConversions",
+    "-unchecked",
+    "-Xfatal-warnings",
+    "-Ykind-projector"
+  ), s"scalacOptions did not match, got instead: ${project.scalacOptions()}")
+}

--- a/mill-tpolecat/src/io/github/davidgregory084/ScalaVersion.scala
+++ b/mill-tpolecat/src/io/github/davidgregory084/ScalaVersion.scala
@@ -8,6 +8,8 @@ object ScalaVersion {
     case ReleaseVersion(major, minor, patch) => ScalaVersion(major.toInt, minor.toInt, patch.toInt)
     case MinorSnapshotVersion(major, minor, patch) => ScalaVersion(major.toInt, minor.toInt, patch.toInt)
     case DottyVersion("0", minor, patch) => ScalaVersion(3, minor.toInt, patch.toInt)
+    // Fallback for Scala 3 NIGHTLY versions. In this scenario we just capture and revert back to the last stable.
+    case Scala3Version(minor, patch) => ScalaVersion(3, minor.toInt, patch.toInt)
   }
 
   val v211 = ScalaVersion(2, 11, 0)


### PR DESCRIPTION
This was originally reported on Discord but it looks like the "unmanaged" community build is filtering out Mill projects that use mill-tpolecat, as you can see in
https://github.com/VirtusLab/community-build3/blob/927f3751011d120c52a5217dfe8ccd3321f49c42/env/prod/config/filtered-projects.txt#L66-L69. From the comment and from playing around it looks to be because if you have a NIGHTLY or RC or anything it will puke. This adds a fallback for Scala 3 projects to revert back to the last stable release in those situations. Hopefully this will allow for those listed Mill projects to still be tested in the community build.